### PR TITLE
Add Gemini token usage logging and fix per-file folder_paths_str rebuild

### DIFF
--- a/lib/ai_engine.py
+++ b/lib/ai_engine.py
@@ -209,7 +209,15 @@ def analyze_with_gemini(content_bytes, mime_type, filename, folder_paths_str, co
                 types.Part.from_bytes(data=content_bytes, mime_type=ai_mime)
             ]
         )
-        
+
+        usage = response.usage_metadata
+        if usage:
+            logger.info(
+                f"  [Tokens] in={usage.prompt_token_count} "
+                f"out={usage.candidates_token_count} "
+                f"total={usage.total_token_count}"
+            )
+
         text = response.text.strip()
         
         # Robust JSON extraction

--- a/services/drive_organizer/main.py
+++ b/services/drive_organizer/main.py
@@ -133,7 +133,9 @@ def scan_folder(folder_id, dry_run=True, csv_path='sorter_dry_run.csv', limit=No
     files = results.get('files', [])
     
     print(f"Found {len(files)} files in {folder_name}. Processing...")
-    
+
+    folder_paths_str = get_category_prompt_str()
+
     for f in files:
         if limit and stats.processed >= limit:
             break
@@ -141,27 +143,26 @@ def scan_folder(folder_id, dry_run=True, csv_path='sorter_dry_run.csv', limit=No
         name = f['name']
         fid = f['id']
         mime = f['mimeType']
-        
+
         # Recursion
         if mime == 'application/vnd.google-apps.folder':
             if recursive:
                 scan_folder(fid, dry_run, csv_path, limit, mode, folder_name=f"{folder_name}/{name}", service=service, recursive=recursive)
             continue
-            
+
         # Validation: check if file is already processed
         is_valid_name = re.match(r'^\d{4}-\d{2}-\d{2} - .* - .*\.\w+$', name)
         if is_valid_name and not name.startswith("0000-00-00"):
             if mode != 'inbox':
                 continue
-        
+
         try:
             content = download_file_content(service, fid, mime)
             if not content: continue
 
             context_hint = f"File located in folder: {folder_name}. Created: {f.get('createdTime')}"
-            
+
             # --- AI ANALYSIS ---
-            folder_paths_str = get_category_prompt_str()
             analysis = analyze_with_gemini(content, mime, name, folder_paths_str, context_hint, file_id=fid)
 
             new_name = generate_new_name(analysis, name, f.get('createdTime'))


### PR DESCRIPTION
- Log input/output/total token counts from response.usage_metadata after each Gemini API call so actual token consumption is visible in logs
- Move get_category_prompt_str() call outside the per-file loop — folder paths never change mid-run so there's no reason to rebuild the string on every iteration

https://claude.ai/code/session_01XDqR6UnJ9JpCLKDhVTrRSY